### PR TITLE
Adjust the price thresholds to match the latest changes

### DIFF
--- a/simple-store.ts
+++ b/simple-store.ts
@@ -4,14 +4,14 @@ import { defineStore } from 'pinia'
 const state = () => ({
 
     gasPlafond: 1200,
-    gasPlafondTarief: 1.5,
+    gasPlafondTarief: 1.45,
     gasJaarVerbruik: 1200,
-    gasJaarTarief: 1.5,
+    gasJaarTarief: 1.45,
 
-    kWhPlafond: 2400,
-    kWhPlafondTarief: 0.7,
-    kWhJaarVerbruik: 2400,
-    kWhJaarTarief: 0.7,
+    kWhPlafond: 2900,
+    kWhPlafondTarief: 0.4,
+    kWhJaarVerbruik: 2900,
+    kWhJaarTarief: 0.4,
 
     kWhJaarTerugLeveringToggle: false,
     kWhJaarTeruglevering: 0,


### PR DESCRIPTION
Zie ook: https://www.rijksoverheid.nl/actueel/nieuws/2022/10/04/vanaf-1-januari-lagere-energierekening-door-verruimd-prijsplafond
